### PR TITLE
Fixing install instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ Currently this role supports the following operating systems and releases.
 Install the playbook via Ansible Galaxy:
 
 ```text
-$ ansible-galaxy install nodesource.nodejs
+$ ansible-galaxy install nodesource.node
 ```
 
 Then configure it as follows:


### PR DESCRIPTION
The package listed under `node` on ansible galaxy.
Until we change that the installation instructions need to refer to that name.
