### PR TITLE
Added ability to set NodeSource repository's Pin-Priority.

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,6 +25,10 @@ Then configure it as follows:
      - nodesource.node
 ```
 
+## Role Variables
+
+- `nodejs_nodesource_pin_priority`: Pin-Priority of the NodeSource repository (default: `500`).
+
 ## Testing
 
 To test this role using Docker:

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -1,2 +1,3 @@
 ---
-# defaults file for nodejs
+# Pin-Priority of NodeSource repository
+nodejs_nodesource_pin_priority: 500

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -17,5 +17,10 @@
 - name: Add NodeSource deb-src repository
   apt_repository: repo='deb-src https://deb.nodesource.com/node {{ ansible_distribution_release }} main' state=present
 
+- name: Add NodeSource repository preferences
+  template:
+    src: etc/apt/preferences.d/deb_nodesource_com_node.pref.2
+    dest: /etc/apt/preferences.d/deb_nodesource_com_node.pref
+
 - name: Install Node.js
   apt: pkg=nodejs state=installed update_cache=yes

--- a/templates/etc/apt/preferences.d/deb_nodesource_com_node.pref.2
+++ b/templates/etc/apt/preferences.d/deb_nodesource_com_node.pref.2
@@ -1,0 +1,5 @@
+# {{ ansible_managed }}
+
+Package: *
+Pin: release o=Node Source
+Pin-Priority: {{ nodejs_nodesource_pin_priority }}


### PR DESCRIPTION
This is very useful on systems where apt is configured with multiple
repositories with different Pin-Priority settings.
A user can set the NodeSource repository's Pin-Priority to a higher number
than, for example, the Pin-Priority of stable-backports repository to prefer
installing Node.js from NodeSource rather than stable-backports.
