### PR TITLE
README: remove broken logo embed

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,5 @@
 # ansible-nodejs-role
 
-<a href="https://nodesource.com"><img src="https://nodesource.com/assets/logo.svg" height="10%" width="10%"></a>
-
 This is an Ansible role which adds the the NodeSource APT repository and installs Node.js.
 
 Currently this role supports the following operating systems and releases.


### PR DESCRIPTION
At first I wanted to fix it by looking up a working URL from the other repos,
but since none of them have a logo I think it can be removed.