### PR TITLE
apt-transport-https installation fails on a new host.

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -37,6 +37,6 @@
   apt:
     pkg: nodejs
     update_cache: yes
-    cache_valid_time: yes
+    cache_valid_time: 3600
     state: installed
 

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -1,21 +1,32 @@
 # Install Node.js using packages crafted by NodeSource
 ---
 - name: Ensure the system can use the HTTPS transport for APT
-  stat: path=/usr/lib/apt/methods/https
+  stat:
+    path: /usr/lib/apt/methods/https
   register: apt_https_transport
 
 - name: Install HTTPS transport for APT
-  apt: pkg=apt-transport-https state=installed
+  apt:
+    pkg: apt-transport-https
+    update_cache: yes
+    cache_valid_time: 3600
+    state: installed
   when: not apt_https_transport.stat.exists
 
 - name: Import the NodeSource GPG key into apt
-  apt_key: url=https://deb.nodesource.com/gpgkey/nodesource.gpg.key state=present
+  apt_key:
+    url: https://deb.nodesource.com/gpgkey/nodesource.gpg.key
+    state: present
 
 - name: Add NodeSource deb repository
-  apt_repository: repo='deb https://deb.nodesource.com/node {{ ansible_distribution_release }} main' state=present
+  apt_repository:
+    repo: 'deb https://deb.nodesource.com/node {{ ansible_distribution_release }} main'
+    state: present
 
 - name: Add NodeSource deb-src repository
-  apt_repository: repo='deb-src https://deb.nodesource.com/node {{ ansible_distribution_release }} main' state=present
+  apt_repository:
+    repo: 'deb-src https://deb.nodesource.com/node {{ ansible_distribution_release }} main'
+    state: present
 
 - name: Add NodeSource repository preferences
   template:
@@ -23,4 +34,9 @@
     dest: /etc/apt/preferences.d/deb_nodesource_com_node.pref
 
 - name: Install Node.js
-  apt: pkg=nodejs state=installed update_cache=yes
+  apt:
+    pkg: nodejs
+    update_cache: yes
+    cache_valid_time: yes
+    state: installed
+


### PR DESCRIPTION
Hello,

The role fails on a new host (e.g., with a old apt cache), since it fails to find one of the apt-transport-https dependencies (libcurl3-gnutls). I've got this error on Vagrant using a Debian Wheezy 7.8 box.

To fix this, we only have to add the update_cache option and the cache_valid_time so that it updates the apt cache if it's older then cache_valid_time value.

The PR fixes that and also adds YAML syntax to the task file, which makes it really easier to read and diff.

Thank you!