### PR TITLE
added task to uninstall before installing new version - allows change…

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -26,5 +26,8 @@
     src: etc/apt/preferences.d/deb_nodesource_com_node.pref.2
     dest: /etc/apt/preferences.d/deb_nodesource_com_node.pref
 
+- name: Uninstall existing installations of Node.js
+  apt: name=nodejs state=absent
+
 - name: Install Node.js
   apt: pkg=nodejs={{ nodejs_version }}.* state=installed update_cache=yes


### PR DESCRIPTION
Allow function to change versions of Node.js if the nodejs version variable changes to allow seamless porting between the available versions.

Tested with DrupalVM on provision, and reprovision between both versions, and has no effect when install hasn't been previously executed from the playbook.
