### PR TITLE
Add support for node 4.x versions (latest)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,15 +1,16 @@
 FROM ubuntu:trusty
 MAINTAINER Mark Wolfe <mark@wolfe.id.au>
 
+# http://docs.ansible.com/ansible/intro_installation.html#latest-releases-via-apt-ubuntu
+RUN apt-get install software-properties-common -y --force-yes
+RUN apt-add-repository ppa:ansible/ansible
 RUN apt-get update
-RUN apt-get install -y --force-yes \
-	python-pycurl \
-	python-apt \
-	ansible \
-	lsb-release
+RUN apt-get install ansible -y --force-yes
+
 
 ENV WORKDIR /build/ansible-nodejs
 ADD . /build/ansible-nodejs
+ADD . /etc/ansible/roles/ansible-nodejs-role
 ADD ./tests/localhosts /etc/ansible/hosts
 
 RUN ansible-playbook $WORKDIR/role.yml -c local

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -2,5 +2,5 @@
 # Pin-Priority of NodeSource repository
 nodejs_nodesource_pin_priority: 500
 
-# 0.10 or 0.12
-nodejs_version: "0.12"
+# 0.10 or 0.12 or 4.x
+nodejs_version: "4.2"

--- a/role.yml
+++ b/role.yml
@@ -2,5 +2,5 @@
 - name: Test the Node.js role
   hosts: all
   sudo: yes
-  tasks:
-    - include: "tasks/main.yml"
+  roles:
+    - role: "ansible-nodejs-role"

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -1,21 +1,30 @@
 # Install Node.js using packages crafted by NodeSource
 ---
 - name: Ensure the system can use the HTTPS transport for APT
-  stat: path=/usr/lib/apt/methods/https
+  stat:
+    path: /usr/lib/apt/methods/https
   register: apt_https_transport
 
 - name: Install HTTPS transport for APT
-  apt: pkg=apt-transport-https state=installed
+  apt: 
+    pkg: apt-transport-https
+    state: installed
   when: not apt_https_transport.stat.exists
 
 - name: Import the NodeSource GPG key into apt
-  apt_key: url=https://deb.nodesource.com/gpgkey/nodesource.gpg.key state=present
+  apt_key:
+    url: https://deb.nodesource.com/gpgkey/nodesource.gpg.key
+    state: present
 
 - name: Add NodeSource deb repository
-  apt_repository: repo='deb https://deb.nodesource.com/node_{{ debian_repo_version }} {{ ansible_distribution_release }} main' state=present
+  apt_repository:
+    repo: 'deb https://deb.nodesource.com/node_{{ debian_repo_version }} {{ ansible_distribution_release }} main'
+    state: present
 
 - name: Add NodeSource deb-src repository
-  apt_repository: repo='deb-src https://deb.nodesource.com/node_{{ debian_repo_version }} {{ ansible_distribution_release }} main' state=present
+  apt_repository:
+    repo: 'deb-src https://deb.nodesource.com/node_{{ debian_repo_version }} {{ ansible_distribution_release }} main'
+    state: present
 
 - name: Add NodeSource repository preferences
   template:
@@ -23,4 +32,8 @@
     dest: /etc/apt/preferences.d/deb_nodesource_com_node.pref
 
 - name: Install Node.js
-  apt: pkg=nodejs={{ nodejs_version }}* state=installed update_cache=yes
+  apt:
+    pkg:
+      - nodejs={{ nodejs_version }}*
+    state: installed
+    update_cache: yes

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -1,9 +1,5 @@
 # Install Node.js using packages crafted by NodeSource
 ---
-- name: Check nodejs_version variable
-  assert:
-    that: nodejs_version in [ "0.10", "0.12" ]
-
 - name: Ensure the system can use the HTTPS transport for APT
   stat: path=/usr/lib/apt/methods/https
   register: apt_https_transport
@@ -16,10 +12,10 @@
   apt_key: url=https://deb.nodesource.com/gpgkey/nodesource.gpg.key state=present
 
 - name: Add NodeSource deb repository
-  apt_repository: repo='deb https://deb.nodesource.com/node_{{ nodejs_version }} {{ ansible_distribution_release }} main' state=present
+  apt_repository: repo='deb https://deb.nodesource.com/node_{{ debian_repo_version }} {{ ansible_distribution_release }} main' state=present
 
 - name: Add NodeSource deb-src repository
-  apt_repository: repo='deb-src https://deb.nodesource.com/node_{{ nodejs_version }} {{ ansible_distribution_release }} main' state=present
+  apt_repository: repo='deb-src https://deb.nodesource.com/node_{{ debian_repo_version }} {{ ansible_distribution_release }} main' state=present
 
 - name: Add NodeSource repository preferences
   template:
@@ -27,4 +23,4 @@
     dest: /etc/apt/preferences.d/deb_nodesource_com_node.pref
 
 - name: Install Node.js
-  apt: pkg=nodejs={{ nodejs_version }}.* state=installed update_cache=yes
+  apt: pkg=nodejs={{ nodejs_version }}* state=installed update_cache=yes

--- a/vars/main.yml
+++ b/vars/main.yml
@@ -1,2 +1,3 @@
 ---
 # vars file for nodejs
+debian_repo_version: "{{ nodejs_version if '4' not in nodejs_version else '4.x' }}"


### PR DESCRIPTION
Adding support for node 4.x and setting the default version to the
latest (4.2)

Removed version check as the documentation in the defaults file should
be enough.

Cleaned up docker file to use latest ansible.

Cleaned up role.yml to run the source as a role rather then including the main task file.

Cleaned up the task file to better represent yaml.

docker build . 
```
Step 11 : RUN node -v
 ---> Running in fd9f9b532976
v4.2.1
 ---> 11d0faf48a7c
```