### PR TITLE
Fix version checking for Debian repo for future versions.

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -16,13 +16,10 @@
     url: https://deb.nodesource.com/gpgkey/nodesource.gpg.key
     state: present
 
-- name: Check if nodejs_version is 4.x or higher
-  set_fact: debian_repo_version="4.x"
-  when: "{{ nodejs_version | version_compare('4.0', '>=') }}"
-
-- name: Check if nodejs_version is 5.x or higher
-  set_fact: debian_repo_version="5.x"
-  when: "{{ nodejs_version | version_compare('5.0', '>=') }}"
+- name: Check if nodejs_version is 0.x
+  set_fact:
+    debian_repo_version: "{{ nodejs_version }}"
+  when: nodejs_version in nodejs_old_versions
 
 - name: Add NodeSource deb repository
   apt_repository:

--- a/vars/main.yml
+++ b/vars/main.yml
@@ -1,3 +1,4 @@
 ---
 # vars file for nodejs
-debian_repo_version: "{{ nodejs_version }}"
+nodejs_old_versions: ['0.10', '0.12']
+debian_repo_version: '{{ nodejs_version | regex_replace("^([1-9]+)\.\d+$", "\\1.x") }}'


### PR DESCRIPTION
Hello,

With this solution, new versions of Node will be covered, assuming that the repo naming convention sticks.

What do you think @wolfeidau? Does this fix #19 ?
