### PR TITLE
Add support for newer nodejs versions, in the form of '5.x'.

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,18 @@ Install the playbook via Ansible Galaxy:
 ```text
 $ ansible-galaxy install nodesource.node
 ```
+Or using the `requirements.yml`
+
+```yaml
+# install the role from galaxy
+- src: nodesource.node
+```
+
+Which is imported as follows.
+
+```
+ansible-galaxy install -r requirements.yml
+```
 
 Then configure it as follows:
 
@@ -26,6 +38,7 @@ Then configure it as follows:
 ## Role Variables
 
 - `nodejs_nodesource_pin_priority`: Pin-Priority of the NodeSource repository (default: `500`).
+- `nodejs_version`: Supports 0.10 or 0.12 and 4.x, 5.x and onward, replacing x with your desired minor version.
 
 ## Testing
 

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -3,4 +3,5 @@
 nodejs_nodesource_pin_priority: 500
 
 # 0.10 or 0.12 and 4.x, 5.x and onward
-nodejs_version: "5.0"
+nodejs_version: "4.2"
+

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -2,5 +2,5 @@
 # Pin-Priority of NodeSource repository
 nodejs_nodesource_pin_priority: 500
 
-# 0.10 or 0.12 or 4.x
-nodejs_version: "4.2"
+# 0.10 or 0.12 and 4.x, 5.x and onward
+nodejs_version: "5.0"

--- a/meta/main.yml
+++ b/meta/main.yml
@@ -4,7 +4,7 @@ galaxy_info:
   description: Installs the NodeSource Node.js binary packages
   company: NodeSource
   license: MIT
-  min_ansible_version: 1.2
+  min_ansible_version: 2.0
   platforms:
    - name: Ubuntu
      versions:

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -6,7 +6,7 @@
   register: apt_https_transport
 
 - name: Install HTTPS transport for APT
-  apt: 
+  apt:
     pkg: apt-transport-https
     state: installed
   when: not apt_https_transport.stat.exists
@@ -15,6 +15,11 @@
   apt_key:
     url: https://deb.nodesource.com/gpgkey/nodesource.gpg.key
     state: present
+
+- name: Check if nodejs_version is 0.x
+  set_fact:
+    debian_repo_version: "{{ nodejs_version }}"
+  when: nodejs_version in zero_versions
 
 - name: Add NodeSource deb repository
   apt_repository:

--- a/vars/main.yml
+++ b/vars/main.yml
@@ -1,3 +1,4 @@
 ---
 # vars file for nodejs
-debian_repo_version: "{{ nodejs_version if '4' not in nodejs_version else '4.x' }}"
+zero_versions: ['0.10', '0.12']
+debian_repo_version: '{{ nodejs_version | regex_replace("^([1-9]+)\.\d+$", "\\1.x") }}'

--- a/vars/main.yml
+++ b/vars/main.yml
@@ -1,4 +1,4 @@
 ---
 # vars file for nodejs
 zero_versions: ['0.10', '0.12']
-debian_repo_version: '{{ nodejs_version | regex_replace("^([1-9]+)\.\d+$", "\\1.x") }}'
+debian_repo_version: '{{ nodejs_version | regex_replace("^([1-9]+)\.\d+$", "\1.x") }}'


### PR DESCRIPTION
Hello,

Following PRs #19 and #20 , here's a fix for support on newer versions, whilst still maintaining compatibility with older versions' repositories.

Thank you.
