### PR TITLE
BugFix: Updating default node_version to v4.3 since …

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -3,4 +3,4 @@
 nodejs_nodesource_pin_priority: 500
 
 # 0.10 or 0.12 or 4.x
-nodejs_version: "4.2"
+nodejs_version: "4.3"


### PR DESCRIPTION
Did this because v4.2 seems to be no longer hosted.
This does not fail gracefully, failing to install Node.js and stopping the playbook.
Bumping the version returns to expected functionality

Fixes #24 