### PR TITLE
Issue 33: Get GPG apt key from keyserver.ubuntu.com

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,8 @@ FROM ubuntu:trusty
 MAINTAINER Mark Wolfe <mark@wolfe.id.au>
 
 # http://docs.ansible.com/ansible/intro_installation.html#latest-releases-via-apt-ubuntu
-RUN apt-get install software-properties-common -y --force-yes
+ENV DEBIAN_FRONTEND=noninteractive
+RUN apt-get update && apt-get install software-properties-common -y --force-yes
 RUN apt-add-repository ppa:ansible/ansible
 RUN apt-get update
 RUN apt-get install ansible -y --force-yes

--- a/role.yml
+++ b/role.yml
@@ -1,6 +1,8 @@
 ---
 - name: Test the Node.js role
   hosts: all
-  sudo: yes
+  become: yes
   roles:
     - role: "ansible-nodejs-role"
+  vars:
+    nodejs_version: '4'

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -13,7 +13,8 @@
 
 - name: Import the NodeSource GPG key into apt
   apt_key:
-    url: https://deb.nodesource.com/gpgkey/nodesource.gpg.key
+    url: https://keyserver.ubuntu.com/pks/lookup?op=get&fingerprint=on&search=0x1655A0AB68576280
+    id: "68576280"
     state: present
 
 - name: Add NodeSource deb repository


### PR DESCRIPTION
Fix some issues with the ``Dockerfile`` and sample ``role.yml``, to demonstrate the problem in #33 on Ubuntu 14.04. Then, fix it by downloading the GPG key from [keyserver.ubuntu.com](https://keyserver.ubuntu.com/pks/lookup?op=get&fingerprint=on&search=0x1655A0AB68576280) instead of https://deb.nodesource.com.