### PR TITLE
Remove the version check to avoid failures.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,6 @@
+/venv
+*.retry
+.molecule
+.vagrant
+/tests/__pycache__
+.cache

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,17 @@
+sudo: required
+
+language: python
+
+services:
+  - docker
+
+before_install:
+  - sudo apt-get -qq update
+  - sudo apt-get install -o Dpkg::Options::="--force-confold" --force-yes -y docker-engine
+
+install:
+  - make
+
+script:
+  - source venv/bin/activate
+  - molecule test

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,13 @@
+# Makefile
+venv: venv/bin/activate
+
+venv/bin/activate: requirements.txt
+	test -d venv || virtualenv -p `which python` venv
+	. venv/bin/activate; pip install -r requirements.txt
+	touch venv/bin/activate
+
+.PHONY:clean
+
+clean:
+	$(RM) -rf venv
+	find . -name "*.pyc" -exec $(RM) -rf {} \;

--- a/README.md
+++ b/README.md
@@ -4,16 +4,30 @@ This is an Ansible role which adds the the NodeSource APT repository and install
 
 Currently this role supports the following operating systems and releases.
 
-* **Ubuntu 12.04 LTS** (Precise Pangolin)
 * **Ubuntu 14.04 LTS** (Trusty Tahr)
+* **Ubuntu 16.04 LTS** (Xenial Xerus)
 
 ## Usage
 
-Install the playbook via Ansible Galaxy:
+You can either:
+
+* Install the playbook via Ansible Galaxy:
 
 ```text
 $ ansible-galaxy install nodesource.node
 ```
+
+* Install the using [requirements.yml via Ansible Galaxy](http://docs.ansible.com/ansible/galaxy.html#installing-multiple-roles-from-a-file):
+
+```yml
+- src: https://github.com/nodesource/ansible-nodejs-role
+```
+
+```text
+$ ansible-galaxy install -r requirements.txt
+```
+
+## Configure
 
 Then configure it as follows:
 
@@ -26,14 +40,15 @@ Then configure it as follows:
 ## Role Variables
 
 - `nodejs_nodesource_pin_priority`: Pin-Priority of the NodeSource repository (default: `500`).
-- `nodejs_version`: Set Node version (options: `0.10` or `0.12` or `4.4`, default: `4.4`)
+- `nodejs_version`: Set Node version (options: `0.10` or `0.12` or `4.6`, default: `4.6`)
 
 ## Testing
 
-To test this role using Docker:
+To test this role using [molecule](https://github.com/metacloud/molecule):
 
 ```
-$ docker build .
+$ make
+$ molecule test
 ```
 
 ## Author

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -3,4 +3,4 @@
 nodejs_nodesource_pin_priority: 500
 
 # 0.10 or 0.12 or 4.x
-nodejs_version: "4.4"
+nodejs_version: "4.6"

--- a/molecule.yml
+++ b/molecule.yml
@@ -1,0 +1,22 @@
+---
+molecule:
+  ignore_paths:
+    - .git
+    - .vagrant
+    - .molecule
+    - venv
+
+ansible:
+  playbook: playbook.yml
+
+docker:
+  containers:
+  - name: ansible-nodejs-01
+    image: ubuntu
+    image_version: xenial
+  - name: ansible-nodejs-02
+    image: ubuntu
+    image_version: trusty
+
+verifier:
+  name: testinfra

--- a/playbook.yml
+++ b/playbook.yml
@@ -1,0 +1,4 @@
+---
+- hosts: all
+  roles:
+    - role: ansible-nodejs-role

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,3 @@
+ansible==2.1
+testinfra==1.3.0
+molecule

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -35,6 +35,6 @@
 - name: Install Node.js
   apt:
     pkg:
-      - nodejs={{ nodejs_version }}*
+      - nodejs
     state: installed
     update_cache: yes

--- a/tests/test_default.py
+++ b/tests/test_default.py
@@ -1,0 +1,12 @@
+import pytest
+from testinfra.utils.ansible_runner import AnsibleRunner
+
+testinfra_hosts = AnsibleRunner('.molecule/ansible_inventory').get_hosts('all')
+
+
+@pytest.mark.parametrize('f', ['/usr/bin/node',
+                               '/usr/bin/npm'])
+def test_etcd_installed(File, f):
+    file = File(f)
+
+    assert file.exists


### PR DESCRIPTION
This pull request adds a few things:
- Bump default version to 4.6
- Adds tests using molecule
- Adds integration with Travis
- Remove the version check to help mitigate #24
