### PR TITLE
Installed is deprecated and will be removed in ansible 2.9

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -8,13 +8,13 @@
 - name: Install HTTPS transport for APT
   apt:
     pkg: apt-transport-https
-    state: installed
+    state: present
   when: not apt_https_transport.stat.exists
 
 - name: Install GPG
   apt:
     pkg: gnupg
-    state: installed
+    state: present
 
 - name: Import the NodeSource GPG key into apt
   apt_key:
@@ -41,5 +41,5 @@
   apt:
     pkg:
       - nodejs
-    state: installed
+    state: present
     update_cache: yes


### PR DESCRIPTION
This fixes this warning:

> TASK [nodejs : Install Node.js] ************************************************
> Saturday 19 May 2018  08:22:31 +0000 (0:00:00.596)       0:07:16.018 **********
> [DEPRECATION WARNING]: State 'installed' is deprecated. Using state 'present'
> instead.. This feature will be removed in version 2.9. Deprecation warnings can
>  be disabled by setting deprecation_warnings=False in ansible.cfg.